### PR TITLE
Update GitHub Actions workflow 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-  #     - name: Set up Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 18
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
 
   #     - name: Install dependencies
   #       run: yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -14,32 +17,33 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
+  #     - name: Set up Node.js
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 18
 
-      - name: Install dependencies
-        run: yarn install
+  #     - name: Install dependencies
+  #       run: yarn install
 
-      - name: Build the site
-        run: yarn build
+  #     - name: Build the site
+  #       run: yarn build
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: pages-artifact
-          path: ./build
+  #     - name: Upload artifact
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: pages-artifact
+  #         path: ./build
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
+  # deploy:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == 'refs/heads/main'
+  #   permissions:
+  #     pages: write
+  #     id-token: write
 
-    steps:
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
-        with:
-          artifact-name: pages-artifact
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       uses: actions/deploy-pages@v2
+  #       with:
+  #         artifact-name: pages-artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           node-version: 22
 
-  #     - name: Install dependencies
-  #       run: yarn install
+      - name: Install dependencies
+        run: yarn install
 
   #     - name: Build the site
   #       run: yarn build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-  #     - name: Build the site
-  #       run: yarn build
+      - name: Build the site
+        run: yarn build
 
   #     - name: Upload artifact
   #       uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,21 +31,21 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pages-artifact
+          name: github-pages
           path: ./build
           if-no-files-found: 'error'
           retention-days: 2
 
-  # deploy:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/main'
-  #   permissions:
-  #     pages: write
-  #     id-token: write
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
 
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       uses: actions/deploy-pages@v2
-  #       with:
-  #         artifact-name: pages-artifact
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact-name: github-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main  # Replace with your default branch if different
-
-  # Optional: Run the workflow manually
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18  # Ensure this matches the required Node.js version
+          node-version: 18
 
       - name: Install dependencies
         run: yarn install
@@ -26,17 +26,20 @@ jobs:
         run: yarn build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
-          path: ./build  # Path to the build output directory
+          name: pages-artifact
+          path: ./build
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      pages: write  # Required to deploy to GitHub Pages
-      id-token: write  # Required for authentication
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2
+        with:
+          artifact-name: pages-artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,13 @@ jobs:
       - name: Build the site
         run: yarn build
 
-  #     - name: Upload artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: pages-artifact
-  #         path: ./build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-artifact
+          path: ./build
+          if-no-files-found: 'error'
+          retention-days: 2
 
   # deploy:
   #   needs: build


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow for deploying to GitHub Pages. The changes focus on improving the workflow's flexibility and updating dependencies.

Improvements to workflow flexibility:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-R9): Added support for running the workflow on pull requests to the `main` branch.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R51): Added a condition to the `deploy` job to ensure it only runs on the `main` branch.

Dependency updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L22-R23): Updated the Node.js version from 18 to 22 in the `Set up Node.js` step.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R51): Updated the `upload-pages-artifact` action to `upload-artifact@v4` and added additional parameters for artifact handling.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R51): Updated the `deploy-pages` action to version 4 and specified the artifact name.