### PR TITLE
Update GitHub Actions deployment configuration for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,26 +15,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build the site
         run: yarn build
-
-      - name: Check for hard links
-        run: find ./build -type f -links +1 -exec ls -l {} \;
-
-      - name: Remove hard links
-        run: |
-          cp -rL build fixed_build
-          mv fixed_build build
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -51,6 +46,10 @@ jobs:
     permissions:
       pages: write
       id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Build the site
         run: yarn build
 
+      - name: Check for hard links
+        run: find ./build -type f -links +1 -exec ls -l {} \;
+
+      - name: Remove hard links
+        run: |
+          cp -rL build fixed_build
+          mv fixed_build build
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,10 @@ jobs:
       - name: Build the site
         run: yarn build
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages
-          path: ./build
-          if-no-files-found: 'error'
-          retention-days: 2
+          path: build
 
   deploy:
     needs: build
@@ -53,6 +50,5 @@ jobs:
 
     steps:
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          artifact_name: "github-pages"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write
@@ -48,4 +48,4 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
         with:
-          artifact-name: github-pages
+          artifact_name: "github-pages"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow configuration in the `.github/workflows/deploy.yml` file. The changes primarily focus on upgrading action versions and improving the deployment process.

### Workflow Configuration Updates:

* Updated `actions/checkout` to version 4 and added `fetch-depth: 0` to ensure the full history is fetched.
* Updated `actions/setup-node` to version 4 and added `cache: yarn` to optimize dependency caching.
* Changed the `yarn install` command to use the `--frozen-lockfile` flag for consistency with the lockfile.
* Replaced `actions/upload-artifact` with `actions/upload-pages-artifact` for uploading build artifacts, and simplified the configuration.
* Added an `environment` section to specify the deployment environment and URL, and updated the `deploy-pages` action to include an `id` for deployment.