### PR TITLE
Fix code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fixes #14

Add permissions to the `build` job in `.github/workflows/deploy.yml` to fix the code scanning alert.

* Add `permissions` section to the `build` job.
* Set `contents: read` and `id-token: write` under `permissions` for the `build` job.
* Minor formatting change in the `deploy` job to add a newline at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/libamtrack/libamtrack.github.io/pull/15?shareId=715def1f-f24d-4c6c-9884-45512fc2e708).