### PR TITLE
Add function status documentation for libamtrack porting progress

### DIFF
--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -8,10 +8,15 @@ sidebar_position: 4
 
 This document provides information about which libamtrack functions have been ported to the pyamtrack Python wrapper. Not all libamtrack functions are currently available in pyamtrack, as the porting process is ongoing.
 
+:::info
+
 The tables below show the status of various function groups:
 - **Fully Ported**: Function is available and tested in pyamtrack
 - **During Porting**: Function is being implemented or tested
 - **Not Ported**: Function is available in libamtrack but not yet ported to pyamtrack
+
+:::
+
 
 ## Particle Data
 

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -11,9 +11,9 @@ This document provides information about which libamtrack functions have been po
 :::info
 
 The tables below show the status of various function groups:
-- **Fully Ported**: Function is available and tested in pyamtrack
-- **During Porting**: Function is being implemented or tested
-- **Not Ported**: Function is available in libamtrack but not yet ported to pyamtrack
+- ✅ **Fully Ported**: Function is available and tested in pyamtrack
+- 🚧 **During Porting**: Function is being implemented or tested
+- ❌ **Not Ported**: Function is available in libamtrack but not yet ported to pyamtrack
 
 :::
 
@@ -24,7 +24,7 @@ Functions for accessing and manipulating particle data.
 
 | Python Module | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `particle` | Not Ported | [AT_ParticleData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataParticle.h#L82) |
+| `particle` | ❌ Not Ported | [AT_ParticleData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataParticle.h#L82) |
 
 ## Material Data
 
@@ -32,7 +32,7 @@ Functions for accessing and manipulating material properties.
 
 | Python Module | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `material` | Not Ported | [AT_MaterialData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataMaterial.h#L82) |
+| `material` | ❌ Not Ported | [AT_MaterialData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataMaterial.h#L82) |
 
 
 ## Converters
@@ -41,16 +41,16 @@ Functions for converting between different physical quantities.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| [`converters.beta_from_energy`](API/converters.md#beta_from_energy) | Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
-| [`converters.energy_from_beta`](API/converters.md#energy_from_beta) | Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
-| `converters.gamma_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L152) |
-| `converters.energy_from_gamma` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L112) |
-| `converters.energy_from_momentum` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L132) |
-| `converters.momentum_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L419) |
-| `converters.dose_from_fluence` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L446) |
-| `converters.fluence_from_dose` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L485) |
-| `converters.energy_per_amu_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L51) |
-| `converters.energy_from_energy_per_amu` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L59) |
+| [`converters.beta_from_energy`](API/converters.md#beta_from_energy) | ✅ Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
+| [`converters.energy_from_beta`](API/converters.md#energy_from_beta) | ✅ Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
+| `converters.gamma_from_energy` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L152) |
+| `converters.energy_from_gamma` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L112) |
+| `converters.energy_from_momentum` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L132) |
+| `converters.momentum_from_energy` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L419) |
+| `converters.dose_from_fluence` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L446) |
+| `converters.fluence_from_dose` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L485) |
+| `converters.energy_per_amu_from_energy` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L51) |
+| `converters.energy_from_energy_per_amu` | ❌ Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L59) |
 
 ## Stopping Power
 
@@ -58,10 +58,10 @@ Functions for calculating stopping power of ions and protons and range of partic
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `stopping.mass_stopping_power` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h#L151) |
-| `stopping.electron_range` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h#L230) |
-| `stopping.csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
-| `stopping.bortfeld_proton_range` | Not Ported | [AT_ProtonAnalyticalBeamParameters.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalBeamParameters.h#L90) |
+| `stopping.mass_stopping_power` | ❌ Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h#L151) |
+| `stopping.electron_range` | ❌ Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h#L230) |
+| `stopping.csda_range` | ❌ Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
+| `stopping.bortfeld_proton_range` | ❌ Not Ported | [AT_ProtonAnalyticalBeamParameters.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalBeamParameters.h#L90) |
 
 ## Energy Loss Straggling
 
@@ -69,7 +69,7 @@ Functions for energy loss straggling calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `straggling.energy_loss_distribution` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c#L362) |
+| `straggling.energy_loss_distribution` | ❌ Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c#L362) |
 
 ## Scattering
 
@@ -77,7 +77,7 @@ Functions for particle scattering calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `scattering.angle_distribution` | Not Ported | [AT_MultipleCoulombScattering.h](https://github.com/libamtrack/library/blob/master/include/AT_MultipleCoulombScattering.h#L247) |
+| `scattering.angle_distribution` | ❌ Not Ported | [AT_MultipleCoulombScattering.h](https://github.com/libamtrack/library/blob/master/include/AT_MultipleCoulombScattering.h#L247) |
 
 ## Proton Pencil Beam Models
 
@@ -85,8 +85,8 @@ Functions for proton pencil beam dose and LET calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `proton.bortfeld_dose` | Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L63) |
-| `proton.wilkens_let` | Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L106) |
+| `proton.bortfeld_dose` | ❌ Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L63) |
+| `proton.wilkens_let` | ❌ Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L106) |
 
 ## Track Structure Models
 
@@ -94,8 +94,8 @@ Functions for track structure calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `track.radial_dose` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
-| `track.track_width` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.radial_dose` | ❌ Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.track_width` | ❌ Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
 
 ## Detector Response Models
 
@@ -103,8 +103,8 @@ Functions for calculating detector response using various models.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `detector.hcp_response` | Not Ported | [AT_SuccessiveConvolutions.h](https://github.com/libamtrack/library/blob/master/include/AT_SuccessiveConvolutions.h) |
-| `detector.gamma_response` | Not Ported | [AT_GammaResponse.h](https://github.com/libamtrack/library/blob/master/include/AT_GammaResponse.h) |
+| `detector.hcp_response` | ❌ Not Ported | [AT_SuccessiveConvolutions.h](https://github.com/libamtrack/library/blob/master/include/AT_SuccessiveConvolutions.h) |
+| `detector.gamma_response` | ❌ Not Ported | [AT_GammaResponse.h](https://github.com/libamtrack/library/blob/master/include/AT_GammaResponse.h) |
 
 ## Cell Survival Models
 
@@ -112,8 +112,8 @@ Functions for calculating cell survival.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `survival.katz_cell_survival` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L154) |
-| `survival.katz_inact_cross_sect` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L62) |
+| `survival.katz_cell_survival` | ❌ Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L154) |
+| `survival.katz_inact_cross_sect` | ❌ Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L62) |
 
 
 ## Contributing to Function Porting

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -36,21 +36,10 @@ Functions for calculating stopping power of particles in materials.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `stopping.calculate_stopping_power` | During Porting | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
-| `stopping.calculate_csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
-| `stopping.calculate_mass_stopping_power` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
-| `stopping.get_stopping_data_from_pstar` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
+| `stopping.mass_stopping_power` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h#L151) |
+| `electron.max_electron_range` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
+| `stopping.csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
 
-## Electron Range
-
-Functions for electron range calculations.
-
-| Python Function | Status | C/C++ Source |
-|-----------------|--------|--------------|
-| [`electron.max_electron_range`](API/electron.md#max_electron_range) | Fully Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
-| `electron.effective_charge_from_energy` | During Porting | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
-| `electron.electron_range_butts` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
-| `electron.electron_range_tabata` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
 
 ## Track Structure Models
 

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -2,9 +2,9 @@
 sidebar_position: 4
 ---
 
-# Function Status
+# Porting Status
 
-## Porting Status Overview
+## Status Overview
 
 This document provides information about which libamtrack functions have been ported to the pyamtrack Python wrapper. Not all libamtrack functions are currently available in pyamtrack, as the porting process is ongoing.
 
@@ -32,13 +32,23 @@ Functions for converting between different physical quantities.
 
 ## Stopping Power
 
-Functions for calculating stopping power of particles in materials.
+Functions for calculating stopping power of ions and protons and range of particles in materials.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
 | `stopping.mass_stopping_power` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h#L151) |
-| `electron.max_electron_range` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
+| `stopping.electron_range` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h#L230) |
 | `stopping.csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
+| `stopping.bortfeld_proton_range` | Not Ported | [AT_ProtonAnalyticalBeamParameters.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalBeamParameters.h#L90) |
+
+
+## Energy Loss Straggling
+
+Functions for energy loss straggling calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `straggling.energy_loss_distribution` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c#L362) |
 
 
 ## Track Structure Models
@@ -47,11 +57,8 @@ Functions for track structure calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `track.calculate_radial_dose` | During Porting | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
-| `track.get_rdd_index` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
-| `track.rdd_katz_point_target` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
-| `track.rdd_katz_extended_target` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
-| `track.rdd_geiss` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.radial_dose` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.track_width` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
 
 ## Cell Survival Models
 
@@ -59,19 +66,9 @@ Functions for calculating cell survival.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `survival.katz_model` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
-| `survival.calculate_survival` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
-| `survival.survival_from_dose` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
+| `survival.katz_cell_survival` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L154) |
+| `survival.katz_inact_cross_sect` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h#L62) |
 
-## Energy Loss Straggling
-
-Functions for energy loss straggling calculations.
-
-| Python Function | Status | C/C++ Source |
-|-----------------|--------|--------------|
-| `straggling.calculate_vavilov_energy_loss` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
-| `straggling.calculate_landau_energy_loss` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
-| `straggling.energy_loss_after_slab` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
 
 ## Contributing to Function Porting
 

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -13,6 +13,23 @@ The tables below show the status of various function groups:
 - **During Porting**: Function is being implemented or tested
 - **Not Ported**: Function is available in libamtrack but not yet ported to pyamtrack
 
+## Particle Data
+
+Functions for accessing and manipulating particle data.
+
+| Python Module | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `particle` | Not Ported | [AT_ParticleData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataParticle.h#L82) |
+
+## Material Data
+
+Functions for accessing and manipulating material properties.
+
+| Python Module | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `material` | Not Ported | [AT_MaterialData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataMaterial.h#L82) |
+
+
 ## Converters
 
 Functions for converting between different physical quantities.
@@ -41,7 +58,6 @@ Functions for calculating stopping power of ions and protons and range of partic
 | `stopping.csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
 | `stopping.bortfeld_proton_range` | Not Ported | [AT_ProtonAnalyticalBeamParameters.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalBeamParameters.h#L90) |
 
-
 ## Energy Loss Straggling
 
 Functions for energy loss straggling calculations.
@@ -50,6 +66,22 @@ Functions for energy loss straggling calculations.
 |-----------------|--------|--------------|
 | `straggling.energy_loss_distribution` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c#L362) |
 
+## Scattering
+
+Functions for particle scattering calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `scattering.angle_distribution` | Not Ported | [AT_MultipleCoulombScattering.h](https://github.com/libamtrack/library/blob/master/include/AT_MultipleCoulombScattering.h#L247) |
+
+## Proton Pencil Beam Models
+
+Functions for proton pencil beam dose and LET calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `proton.bortfeld_dose` | Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L63) |
+| `proton.wilkens_let` | Not Ported | [AT_ProtonAnalyticalModels.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalModels.h#L106) |
 
 ## Track Structure Models
 
@@ -59,6 +91,15 @@ Functions for track structure calculations.
 |-----------------|--------|--------------|
 | `track.radial_dose` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
 | `track.track_width` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+
+## Detector Response Models
+
+Functions for calculating detector response using various models.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `detector.hcp_response` | Not Ported | [AT_SuccessiveConvolutions.h](https://github.com/libamtrack/library/blob/master/include/AT_SuccessiveConvolutions.h) |
+| `detector.gamma_response` | Not Ported | [AT_GammaResponse.h](https://github.com/libamtrack/library/blob/master/include/AT_GammaResponse.h) |
 
 ## Cell Survival Models
 

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 4
+---
+
+# Function Status
+
+## Porting Status Overview
+
+This document provides information about which libamtrack functions have been ported to the pyamtrack Python wrapper. Not all libamtrack functions are currently available in pyamtrack, as the porting process is ongoing.
+
+The tables below show the status of various function groups:
+- **Fully Ported**: Function is available and tested in pyamtrack
+- **During Porting**: Function is being implemented or tested
+- **Not Ported**: Function is available in libamtrack but not yet ported to pyamtrack
+
+## Converters
+
+Functions for converting between different physical quantities.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| [`converters.beta_from_energy`](API/converters.md#beta_from_energy) | Fully Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L39) |
+| [`converters.energy_from_beta`](API/converters.md#energy_from_beta) | Fully Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L55) |
+| `converters.energy_from_momentum` | Not Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L90) |
+| `converters.momentum_from_energy` | Not Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L68) |
+
+## Stopping Power
+
+Functions for calculating stopping power of particles in materials.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `stopping.calculate_stopping_power` | During Porting | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
+| `stopping.calculate_csda_range` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
+| `stopping.calculate_mass_stopping_power` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
+| `stopping.get_stopping_data_from_pstar` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
+
+## Electron Range
+
+Functions for electron range calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| [`electron.max_electron_range`](API/electron.md#max_electron_range) | Fully Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
+| `electron.effective_charge_from_energy` | During Porting | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
+| `electron.electron_range_butts` | Not Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
+| `electron.electron_range_tabata` | Not Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
+
+## Track Structure Models
+
+Functions for track structure calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `track.calculate_radial_dose` | During Porting | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+| `track.get_rdd_index` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+| `track.rdd_katz_point_target` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+| `track.rdd_katz_extended_target` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+| `track.rdd_geiss` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+
+## Cell Survival Models
+
+Functions for calculating cell survival.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `survival.katz_model` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
+| `survival.calculate_survival` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
+| `survival.survival_from_dose` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
+
+## Energy Loss Straggling
+
+Functions for energy loss straggling calculations.
+
+| Python Function | Status | C/C++ Source |
+|-----------------|--------|--------------|
+| `straggling.calculate_vavilov_energy_loss` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
+| `straggling.calculate_landau_energy_loss` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
+| `straggling.energy_loss_after_slab` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
+
+## Contributing to Function Porting
+
+If you're interested in helping port more functions from libamtrack to pyamtrack, please visit the [pyamtrack GitHub repository](https://github.com/libamtrack/pyamtrack) for more information on how to contribute.
+
+The porting process typically involves:
+1. Adding C++ wrapper functions in the pyamtrack source code
+2. Binding these functions to Python using pybind11
+3. Adding proper type handling for different input types (scalars, lists, numpy arrays)
+4. Writing tests to ensure the ported functions work correctly
+5. Documenting the new functions
+
+Your contributions would be greatly appreciated!

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -19,10 +19,16 @@ Functions for converting between different physical quantities.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| [`converters.beta_from_energy`](API/converters.md#beta_from_energy) | Fully Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L39) |
-| [`converters.energy_from_beta`](API/converters.md#energy_from_beta) | Fully Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L55) |
-| `converters.energy_from_momentum` | Not Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L90) |
-| `converters.momentum_from_energy` | Not Ported | [AT_PhysicsRoutines.c](https://github.com/libamtrack/library/blob/master/src/AT_PhysicsRoutines.c#L68) |
+| [`converters.beta_from_energy`](API/converters.md#beta_from_energy) | Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
+| [`converters.energy_from_beta`](API/converters.md#energy_from_beta) | Fully Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L68) |
+| `converters.gamma_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L152) |
+| `converters.energy_from_gamma` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L112) |
+| `converters.energy_from_momentum` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L132) |
+| `converters.momentum_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L419) |
+| `converters.dose_from_fluence` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L446) |
+| `converters.fluence_from_dose` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L485) |
+| `converters.energy_per_amu_from_energy` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L51) |
+| `converters.energy_from_energy_per_amu` | Not Ported | [AT_PhysicsRoutines.h](https://github.com/libamtrack/library/blob/master/include/AT_PhysicsRoutines.h#L59) |
 
 ## Stopping Power
 
@@ -30,10 +36,10 @@ Functions for calculating stopping power of particles in materials.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `stopping.calculate_stopping_power` | During Porting | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
-| `stopping.calculate_csda_range` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
-| `stopping.calculate_mass_stopping_power` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
-| `stopping.get_stopping_data_from_pstar` | Not Ported | [AT_StoppingPower.c](https://github.com/libamtrack/library/blob/master/src/AT_StoppingPower.c) |
+| `stopping.calculate_stopping_power` | During Porting | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
+| `stopping.calculate_csda_range` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
+| `stopping.calculate_mass_stopping_power` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
+| `stopping.get_stopping_data_from_pstar` | Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h) |
 
 ## Electron Range
 
@@ -41,10 +47,10 @@ Functions for electron range calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| [`electron.max_electron_range`](API/electron.md#max_electron_range) | Fully Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
-| `electron.effective_charge_from_energy` | During Porting | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
-| `electron.electron_range_butts` | Not Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
-| `electron.electron_range_tabata` | Not Ported | [AT_ElectronRange.c](https://github.com/libamtrack/library/blob/master/src/AT_ElectronRange.c) |
+| [`electron.max_electron_range`](API/electron.md#max_electron_range) | Fully Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
+| `electron.effective_charge_from_energy` | During Porting | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
+| `electron.electron_range_butts` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
+| `electron.electron_range_tabata` | Not Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h) |
 
 ## Track Structure Models
 
@@ -52,11 +58,11 @@ Functions for track structure calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `track.calculate_radial_dose` | During Porting | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
-| `track.get_rdd_index` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
-| `track.rdd_katz_point_target` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
-| `track.rdd_katz_extended_target` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
-| `track.rdd_geiss` | Not Ported | [AT_RDD.c](https://github.com/libamtrack/library/blob/master/src/AT_RDD.c) |
+| `track.calculate_radial_dose` | During Porting | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.get_rdd_index` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.rdd_katz_point_target` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.rdd_katz_extended_target` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
+| `track.rdd_geiss` | Not Ported | [AT_RDD.h](https://github.com/libamtrack/library/blob/master/include/AT_RDD.h) |
 
 ## Cell Survival Models
 
@@ -64,9 +70,9 @@ Functions for calculating cell survival.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `survival.katz_model` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
-| `survival.calculate_survival` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
-| `survival.survival_from_dose` | Not Ported | [AT_KatzModel.c](https://github.com/libamtrack/library/blob/master/src/AT_KatzModel.c) |
+| `survival.katz_model` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
+| `survival.calculate_survival` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
+| `survival.survival_from_dose` | Not Ported | [AT_KatzModel.h](https://github.com/libamtrack/library/blob/master/include/AT_KatzModel.h) |
 
 ## Energy Loss Straggling
 
@@ -74,9 +80,9 @@ Functions for energy loss straggling calculations.
 
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `straggling.calculate_vavilov_energy_loss` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
-| `straggling.calculate_landau_energy_loss` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
-| `straggling.energy_loss_after_slab` | Not Ported | [AT_EnergyLoss.c](https://github.com/libamtrack/library/blob/master/src/AT_EnergyLoss.c) |
+| `straggling.calculate_vavilov_energy_loss` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
+| `straggling.calculate_landau_energy_loss` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
+| `straggling.energy_loss_after_slab` | Not Ported | [AT_EnergyLoss.h](https://github.com/libamtrack/library/blob/master/include/AT_EnergyLoss.h) |
 
 ## Contributing to Function Porting
 


### PR DESCRIPTION
This pull request adds a new documentation file `docs/python/function-status.md` that provides an overview of the porting status of various libamtrack functions to the pyamtrack Python wrapper. The document categorizes functions into groups and indicates their porting status with clear labels.

Documentation updates:

* [`docs/python/function-status.md`](diffhunk://#diff-c5743b1390ed2d65cd885c3f76f8f7e6c4329e54af3dd62fe822d7c1fbde9391R1-R130): Created a new file to document the porting status of libamtrack functions to pyamtrack. The document includes tables that categorize functions based on their current porting status (Fully Ported, During Porting, Not Ported) and provides links to the corresponding C/C++ source files.

The new documentation also includes a section on how to contribute to the porting process, outlining the steps required to add new functions to pyamtrack.