### PR TITLE
29 describe materials

### DIFF
--- a/docs/python/API/materials.md
+++ b/docs/python/API/materials.md
@@ -1,0 +1,136 @@
+# Materials
+
+The library provides a comprehensive material system for particle transport calculations, including predefined materials commonly used in particle therapy and radiation physics.
+
+## Overview
+
+Each material is characterized by physical properties, including density, mean ionization potential, and atomic properties.
+
+## Material Properties
+
+Each Material object has the following properties:
+
+- **id** (`int`): Unique identifier for the material
+- **name** (`str`): Full name of the material
+- **density_g_cm3** (`float`): Density in g/cm³
+- **I_eV** (`float`): Mean ionization potential in eV
+- **average_A** (`float`): Average mass number
+- **average_Z** (`float`): Average atomic number
+- **phase** (`int`): Physical state (condensed or gaseous)
+
+Additional properties for advanced calculations:
+- **alpha_g_cm2_MeV** (`float`): Fit parameter for power-law representation of stopping power
+- **p_MeV** (`float`): Fit parameter for power-law representation of stopping power
+- **m_g_cm2** (`float`): Fit parameter for linear representation of fluence changes
+
+## Using Materials
+
+### Creating Material Objects
+
+Materials can be created either by ID or name:
+
+```python
+import pyamtrack.materials as materials
+
+# Create by ID
+water = materials.Material(1)  # Water, Liquid
+
+# Create by name
+aluminum = materials.Material("Aluminum")
+```
+
+### Predefined Materials
+
+Common materials are available as module attributes:
+
+```python
+import pyamtrack.materials as materials
+
+# Access predefined materials
+water = materials.water_liquid    # ID: 1
+air = materials.air              # ID: 2
+pmma = materials.pmma           # ID: 3
+```
+
+### Accessing Properties
+
+```python
+# Get material properties
+print(f"Water density: {water.density_g_cm3} g/cm³")
+print(f"Water I-value: {water.I_eV} eV")
+print(f"Water phase: {water.phase}")
+```
+
+## Available Materials
+
+You can get information about available materials using several utility functions:
+
+### List All Materials
+```python
+import pyamtrack.materials as materials
+
+# Get all material IDs
+ids = materials.get_ids()
+
+# Get human-readable names
+names = materials.get_long_names()
+
+# Get programmatic names (lowercase, underscores)
+short_names = materials.get_names()
+```
+
+### Common Materials Reference
+
+| Material | ID | Density (g/cm³) | Common Use |
+|----------|-------|----------------|------------|
+| Water, Liquid | 1 | 1.0 | Reference material, body tissue equivalent |
+| Air | 2 | 0.001225 | Atmospheric medium |
+| PMMA | 3 | 1.19 | Phantom material |
+| Aluminum | 4 | 2.7 | Beam modifiers |
+
+## Error Handling
+
+PyAMTrack includes robust error handling for material operations:
+
+```python
+try:
+    # Try to create material with invalid ID
+    invalid_material = materials.Material(9999)
+except ValueError as e:
+    print(f"Error: {e}")
+
+try:
+    # Try to create material with invalid name
+    invalid_material = materials.Material("Invalid Material")
+except ValueError as e:
+    print(f"Error: {e}")
+```
+
+## Using Materials in Calculations
+
+Materials are used throughout pyamtack for various calculations:
+
+```python
+import pyamtrack
+import pyamtrack.materials as materials
+
+# Calculate electron range in different materials
+energy = 100.0  # MeV
+range_water = pyamtrack.stopping.electron_range(energy, material=materials.water_liquid)
+range_air = pyamtrack.stopping.electron_range(energy, material=materials.air)
+
+print(f"Range in water: {range_water:.2e} m")
+print(f"Range in air: {range_air:.2e} m")
+```
+
+## Notes
+
+- Material properties are based on standard reference data
+- Density values are at standard temperature and pressure where applicable
+- The material system supports both simple usage with predefined materials and advanced usage with detailed physical properties
+
+## See Also
+
+- ICRU Report 49: Stopping Powers and Ranges for Protons and Alpha Particles
+- NIST Standard Reference Database
+- PyAMTrack API Reference for complete material specifications

--- a/docs/python/API/materials.md
+++ b/docs/python/API/materials.md
@@ -108,7 +108,7 @@ except ValueError as e:
 
 ## Using Materials in Calculations
 
-Materials are used throughout pyamtack for various calculations:
+Materials are used throughout pyamtrack for various calculations:
 
 ```python
 import pyamtrack

--- a/docs/python/API/stopping/electron_range.md
+++ b/docs/python/API/stopping/electron_range.md
@@ -19,9 +19,9 @@ Calculate the maximum electron range in a material using different stopping powe
 
 - **`material`** (optional): The material through which the electrons travel. Can be specified as:
   - An integer ID (e.g., `1` for water)
-  - A [`Material`](../API/materials.md) object
+  - A [`Material`](../materials.md) object
   - Defaults to `1` (liquid water)
-  See the [Materials documentation](../API/materials.md) for detailed information about available materials.
+  See the [Materials documentation](../materials.md) for detailed information about available materials.
 
 - **`model`** (optional): The stopping power model to use. Can be specified as:
   - A string name (e.g., `"tabata"`)

--- a/docs/python/API/stopping/electron_range.md
+++ b/docs/python/API/stopping/electron_range.md
@@ -1,0 +1,159 @@
+# Electron Range
+
+The `electron_range` function calculates the maximum distance that electrons can travel in a material before losing all their energy. This calculation can be performed using various theoretical and empirical models.
+
+## Function Purpose
+
+Calculate the maximum electron range in a material using different stopping power models. This is essential for:
+- Radiation therapy treatment planning
+- Shielding calculations
+- Detector design
+- Radiation protection
+
+## Input Parameters
+
+- **`input`**: The electron energy in MeV. The function accepts:
+  - A single value as `float` or `int`
+  - A `numpy.ndarray` of energy values
+  - A Python `list` of energy values
+
+- **`material`** (optional): The material through which the electrons travel. Can be specified as:
+  - An integer ID (e.g., `1` for water)
+  - A [`Material`](../API/materials.md) object
+  - Defaults to `1` (liquid water)
+  See the [Materials documentation](../API/materials.md) for detailed information about available materials.
+
+- **`model`** (optional): The stopping power model to use. Can be specified as:
+  - A string name (e.g., `"tabata"`)
+  - An integer ID (e.g., `7` for Tabata model)
+  - Defaults to `"tabata"`
+
+### Available Models
+
+| Model Name | ID | Description |
+|------------|------|-------------|
+| `"butts_katz"` | 2 | Butts & Katz model, suitable for track structure calculations |
+| `"waligorski"` | 3 | Waligorski model, optimized for radiobiology applications |
+| `"geiss"` | 4 | Geiss model, focused on heavy ion interactions |
+| `"scholz"` | 5 | Original Scholz model |
+| `"edmund"` | 6 | Edmund model |
+| `"tabata"` | 7 | Tabata model (default), widely used empirical model |
+| `"scholz_new"` | 8 | Updated Scholz model with improved accuracy |
+
+## Output
+
+The function returns the calculated range(s) in meters as:
+- A `float` for a single input value
+- A `numpy.ndarray` for NumPy array input
+- A Python `list` for list input
+
+## Notes
+
+- The range values represent the maximum distance electrons can travel in the material
+- Different models may give varying results due to different theoretical approaches
+- Model variations typically stay within physically reasonable bounds
+- The function supports vectorized operations for efficient batch calculations
+- Results scale correctly with energy (higher energy = longer range)
+- All models work with all available materials
+
+## Example Usage
+
+### Basic Usage with Default Model
+```python
+import pyamtrack
+
+energy = 100.0  # MeV
+range_m = pyamtrack.stopping.electron_range(energy)
+print(f"Range in water: {range_m:.2e} m")
+```
+
+### Using Different Materials
+```python
+import pyamtrack
+from pyamtrack import materials
+
+energy = 100.0  # MeV
+
+# Using material ID
+range_water = pyamtrack.stopping.electron_range(
+    energy, 
+    material=1  # water
+)
+
+# Using Material object
+range_air = pyamtrack.stopping.electron_range(
+    energy,
+    material=materials.air
+)
+
+print(f"Range in water: {range_water:.2e} m")
+print(f"Range in air: {range_air:.2e} m")
+```
+
+### Using Different Models
+```python
+import pyamtrack
+
+energy = 100.0  # MeV
+
+# Using model name
+range_tabata = pyamtrack.stopping.electron_range(
+    energy,
+    model="tabata"
+)
+
+# Using model ID
+range_scholz = pyamtrack.stopping.electron_range(
+    energy,
+    model=5  # scholz model
+)
+
+print(f"Range (Tabata): {range_tabata:.2e} m")
+print(f"Range (Scholz): {range_scholz:.2e} m")
+```
+
+### Batch Calculations
+```python
+import pyamtrack
+import numpy as np
+
+energies = np.array([10.0, 50.0, 100.0, 500.0])  # MeV
+ranges = pyamtrack.stopping.electron_range(energies)
+print(f"Ranges: {ranges}")
+```
+
+## Error Handling
+
+The function includes comprehensive error checking:
+
+```python
+import pyamtrack
+
+try:
+    # Invalid material
+    range_invalid = pyamtrack.stopping.electron_range(
+        100.0,
+        material="invalid"
+    )
+except TypeError as e:
+    print(f"Material error: {e}")
+
+try:
+    # Invalid model
+    range_invalid = pyamtrack.stopping.electron_range(
+        100.0,
+        model="invalid_model"
+    )
+except RuntimeError as e:
+    print(f"Model error: {e}")
+```
+
+## See Also
+
+- [Materials Documentation](../materials.md) - Details about available materials
+- ICRU Report 37 - Stopping Powers for Electrons and Positrons
+- The Physics of Radiation Therapy (F.M. Khan) - Chapter on electron interactions
+- Original model papers:
+  - Tabata et al. (1972)
+  - Butts and Katz (1967)
+  - Scholz and Kraft (1994)

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -32,7 +32,7 @@ Functions for accessing and manipulating material properties.
 
 | Python Module | Status | C/C++ Source |
 |-----------------|--------|--------------|
-| `material` | 🚧 During Porting | [AT_MaterialData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataMaterial.h#L82) |
+| [`materials`](API/materials.md) | ✅ Fully Ported | [AT_MaterialData.h](https://github.com/libamtrack/library/blob/master/include/AT_DataMaterial.h#L82) |
 
 
 ## Converters

--- a/docs/python/function-status.md
+++ b/docs/python/function-status.md
@@ -59,7 +59,7 @@ Functions for calculating stopping power of ions and protons and range of partic
 | Python Function | Status | C/C++ Source |
 |-----------------|--------|--------------|
 | `stopping.mass_stopping_power` | ❌ Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_StoppingPower.h#L151) |
-| `stopping.electron_range` | 🚧 During Porting | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h#L230) |
+| [`stopping.electron_range`](API/stopping/electron_range.md) | ✅ Fully Ported | [AT_ElectronRange.h](https://github.com/libamtrack/library/blob/master/include/AT_ElectronRange.h#L230) |
 | `stopping.csda_range` | ❌ Not Ported | [AT_StoppingPower.h](https://github.com/libamtrack/library/blob/master/include/AT_DataRange.h#L112) |
 | `stopping.bortfeld_proton_range` | ❌ Not Ported | [AT_ProtonAnalyticalBeamParameters.h](https://github.com/libamtrack/library/blob/master/include/AT_ProtonAnalyticalBeamParameters.h#L90) |
 


### PR DESCRIPTION
This pull request includes significant updates to the documentation for the materials and electron range functionalities in the `pyamtrack` library. The updates provide comprehensive details on the material system and the electron range calculation function, along with examples and error handling.

Documentation improvements:

* [`docs/python/API/materials.md`](diffhunk://#diff-6d56371a5ff40a4bca7e90a32340082c1f7c3099a4552a210ee95cd8c576daadR1-R136): Added detailed documentation for the material system, including properties, predefined materials, and usage examples.
* [`docs/python/API/stopping/electron_range.md`](diffhunk://#diff-fd5ea78929dbee36bb9288f1632bb420b31fc03744757e7c812f5000b0cb92b1R1-R159): Added detailed documentation for the `electron_range` function, including input parameters, available models, example usage, and error handling.

Status updates:

* [`docs/python/function-status.md`](diffhunk://#diff-c5743b1390ed2d65cd885c3f76f8f7e6c4329e54af3dd62fe822d7c1fbde9391L35-R35): Updated the status of the `materials` module and the `stopping.electron_range` function to indicate they are fully ported. [[1]](diffhunk://#diff-c5743b1390ed2d65cd885c3f76f8f7e6c4329e54af3dd62fe822d7c1fbde9391L35-R35) [[2]](diffhunk://#diff-c5743b1390ed2d65cd885c3f76f8f7e6c4329e54af3dd62fe822d7c1fbde9391L62-R62)