### PR TITLE
Add group for Docusaurus in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request makes a small configuration improvement to the Dependabot settings. The change introduces a new group for Docusaurus dependencies, which will help organize and manage updates to all packages matching the `@docusaurus*` pattern.

* Added a `docusaurus` group to the Dependabot configuration, grouping all dependencies matching `@docusaurus*` for more organized updates. (`.github/dependabot.yml`)